### PR TITLE
Fix whitespace inside inline code tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+      - id: go-vet
+      - id: go-imports
+      - id: go-cyclo
+        args: [-over=15]
+      - id: go-mod-tidy
+      - id: go-unit-tests
+
+  - repo: https://github.com/tekwizely/pre-commit-golang
+    rev: v1.0.0-rc.1
+    hooks:
+      - id: go-staticcheck-pkg
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.43.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   - repo: https://github.com/tekwizely/pre-commit-golang
     rev: v1.0.0-rc.1
     hooks:
-      - id: go-staticcheck-pkg
+      - id: go-staticcheck-mod
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.43.0


### PR DESCRIPTION
## Summary
- gohtml.Format()がインラインの`<code>`タグ内に余分な空白（改行とインデント）を追加してしまう問題を修正
- `formatHTML()`関数を追加し、整形後に`<code>`タグ内の空白を除去
- `Generate()`関数をリファクタリングしてcyclomatic complexityを削減
- staticcheckの警告を修正
- pre-commitの`go-staticcheck-pkg`を`go-staticcheck-mod`に変更（go modules互換性のため）

## Test plan
- [x] `go build ./...` でビルド成功
- [x] `gocyclo -over 15 .` でエラーなし
- [x] `staticcheck ./...` でエラーなし
- [x] pre-commit hooks がすべてパス
- [ ] blog-sourceで`nebel generate`を実行し、インラインコードの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)