### PR TITLE
Increase post generation limit from 3 to 10

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -100,7 +100,7 @@ func writePostFiles(posts []*Post) error {
 			return err
 		}
 
-		if pos > len(posts)-3 {
+		if pos > len(posts)-10 {
 			outputDir := filepath.Join("public", post.Path)
 			if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
 				return err


### PR DESCRIPTION
## Summary
- Increases the number of individual post HTML files generated from latest 3 posts to latest 10 posts
- Improves site coverage while maintaining the performance optimization of not regenerating all posts

## Test plan
- [ ] Run `nebel generate` and verify that up to 10 recent posts have HTML files generated
- [ ] Confirm older posts beyond the 10 most recent are not regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)