### PR TITLE
Update Carina lexer for PascalCase types and current keyword set

### DIFF
--- a/carina_lexer.go
+++ b/carina_lexer.go
@@ -19,8 +19,11 @@ func init() {
 					// Comments
 					{Pattern: `#.*$`, Type: chroma.Comment, Mutator: nil},
 
-					// Keywords
-					{Pattern: `\b(provider|let|read|backend|import|as|input|output)\b`, Type: chroma.Keyword, Mutator: nil},
+					// Keywords (storage, declaration, control, other) — see carina-core keywords.rs
+					{Pattern: `\b(fn|let|arguments|attributes|backend|exports|moved|provider|removed|upstream_state|validation|else|for|if|in|import|read|require|use)\b`, Type: chroma.Keyword, Mutator: nil},
+
+					// Null literal
+					{Pattern: `\bnull\b`, Type: chroma.KeywordConstant, Mutator: nil},
 
 					// Built-in types/functions
 					{Pattern: `\b(ref|list|bool|cidr|string|number)\b`, Type: chroma.KeywordType, Mutator: nil},
@@ -28,14 +31,16 @@ func init() {
 					// Booleans
 					{Pattern: `\b(true|false)\b`, Type: chroma.KeywordConstant, Mutator: nil},
 
-					// Resource types (aws.s3.bucket, etc.)
-					{Pattern: `(aws|awscc|gcp|azure)\.[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)*`, Type: chroma.NameClass, Mutator: nil},
+					// Resource types (aws.s3.bucket, awscc.ec2.SecurityGroup, etc.)
+					// Last segment can be PascalCase (new casing) or snake_case (legacy)
+					{Pattern: `(aws|awscc|gcp|azure)\.[a-z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*`, Type: chroma.NameClass, Mutator: nil},
 
 					// Region constants (aws.Region.xxx)
 					{Pattern: `aws\.Region\.[a-z][a-z0-9_]*`, Type: chroma.NameConstant, Mutator: nil},
 
 					// Strings
 					{Pattern: `"`, Type: chroma.StringDouble, Mutator: chroma.Push("string")},
+					{Pattern: `'`, Type: chroma.StringSingle, Mutator: chroma.Push("sstring")},
 
 					// Numbers
 					{Pattern: `\b[0-9]+\b`, Type: chroma.NumberInteger, Mutator: nil},
@@ -46,11 +51,11 @@ func init() {
 					// Punctuation
 					{Pattern: `[{}()\[\],.]`, Type: chroma.Punctuation, Mutator: nil},
 
-					// Property names (at the start of a line, before =)
-					{Pattern: `^\s*([a-z][a-z0-9_]*)\s*(?==)`, Type: chroma.NameAttribute, Mutator: nil},
+					// Property names (identifier directly followed by `=`)
+					{Pattern: `[a-zA-Z][a-zA-Z0-9_]*(?=\s*=[^=])`, Type: chroma.NameAttribute, Mutator: nil},
 
 					// Identifiers
-					{Pattern: `[a-z][a-z0-9_]*`, Type: chroma.NameVariable, Mutator: nil},
+					{Pattern: `[a-zA-Z][a-zA-Z0-9_]*`, Type: chroma.NameVariable, Mutator: nil},
 
 					// Whitespace
 					{Pattern: `\s+`, Type: chroma.Text, Mutator: nil},
@@ -59,6 +64,11 @@ func init() {
 					{Pattern: `\\.`, Type: chroma.StringEscape, Mutator: nil},
 					{Pattern: `"`, Type: chroma.StringDouble, Mutator: chroma.Pop(1)},
 					{Pattern: `[^"\\]+`, Type: chroma.StringDouble, Mutator: nil},
+				},
+				"sstring": {
+					{Pattern: `\\.`, Type: chroma.StringEscape, Mutator: nil},
+					{Pattern: `'`, Type: chroma.StringSingle, Mutator: chroma.Pop(1)},
+					{Pattern: `[^'\\]+`, Type: chroma.StringSingle, Mutator: nil},
 				},
 			}
 		},


### PR DESCRIPTION
## Summary
- Carinaのリソース型がsnake_caseからPascalCase（例: `awscc.ec2.SecurityGroup`）に移行したのに合わせて、シンタックスハイライトのパターンを更新
- シングルクォート文字列（`'literal'`）が正しく1つの文字列トークンとして塗られるようstateを追加
- キーワードリストをcarina-coreの`keywords.rs`と一致させた（`exports`, `upstream_state` などを追加、旧 `as`/`input`/`output` を削除）
- 属性名と変数参照がそれぞれ `NameAttribute` / `NameVariable` の別トークン型として出力されるよう、属性名パターンを行頭縛りからlookaheadベースに変更

## Test plan
- [x] `go build` でlexer変更が問題なくビルドできる
- [x] pre-commit hook（go fmt, go vet, go imports, staticcheck, unit tests）が全部通る
- [x] blog-source側で `nebel generate` を実行し、`SecurityGroup` や `'Web security group'`、`Name` などがひと続きで色付けされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)